### PR TITLE
Add Bootstrap stats overview

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from services.activities import ActivityService
 from services.housing import HousingService
 from services.restaurants import RestaurantService
 from utils.translations import load_translations, get_translation, translations
+from utils.stats import compute_stats
 
 app = Flask(__name__)
 app.secret_key = "/Xfn,MN~s}.;q1M1'Om`YD;x_-<ACZ"
@@ -32,6 +33,7 @@ def load_snapshots():
 def save_snapshots(snapshots):
     with open(SNAPSHOT_FILE, 'w', encoding='utf-8') as f:
         json.dump(snapshots, f, ensure_ascii=False, indent=2)
+
 
 def search_activities(country, parc, logs=None):
     if logs is None:
@@ -264,6 +266,15 @@ def get_current_language():
 @app.context_processor
 def utility_processor():
     return dict(translate=get_translation)
+
+@app.route('/stats')
+def stats_view():
+    snapshots = load_snapshots()
+    if not snapshots:
+        return render_template('stats.html', stats=None, translate=get_translation)
+    data = snapshots[-1]['data']
+    stats_data = compute_stats(data)
+    return render_template('stats.html', stats=stats_data, translate=get_translation)
 
 @app.route('/snapshots', methods=['GET'])
 def snapshot_manager():

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,9 @@
             <a href="/snapshots" class="btn btn-primary ms-3">
                 <i class="bi bi-archive"></i> Snapshots
             </a>
+            <a href="/stats" class="btn btn-success ms-3">
+                <i class="bi bi-bar-chart"></i> {{ translate('stats') }}
+            </a>
             <div class="switch" data-language="{{ session.get('language', 'fr') }}" onclick="toggleLanguage(this)">
                 <div class="switch-labels">
                     <span class="fr">FR</span>

--- a/templates/snapshots.html
+++ b/templates/snapshots.html
@@ -17,6 +17,9 @@
             <a href="/snapshots" class="btn btn-primary ms-3">
                 <i class="bi bi-archive"></i> Snapshots
             </a>
+            <a href="/stats" class="btn btn-success ms-3">
+                <i class="bi bi-bar-chart"></i> {{ translate('stats') }}
+            </a>
             <div class="switch" data-language="{{ session.get('language', 'fr') }}" onclick="toggleLanguage(this)">
                 <div class="switch-labels">
                     <span class="fr">FR</span>

--- a/templates/snapshots_creating.html
+++ b/templates/snapshots_creating.html
@@ -17,6 +17,9 @@
             <a href="/snapshots" class="btn btn-primary ms-3">
                 <i class="bi bi-archive"></i> Snapshots
             </a>
+            <a href="/stats" class="btn btn-success ms-3">
+                <i class="bi bi-bar-chart"></i> {{ translate('stats') }}
+            </a>
             <div class="switch" data-language="{{ session.get('language', 'fr') }}" onclick="toggleLanguage(this)">
                 <div class="switch-labels">
                     <span class="fr">FR</span>

--- a/templates/snapshots_detail.html
+++ b/templates/snapshots_detail.html
@@ -17,6 +17,9 @@
             <a href="/snapshots" class="btn btn-primary ms-3">
                 <i class="bi bi-archive"></i> Snapshots
             </a>
+            <a href="/stats" class="btn btn-success ms-3">
+                <i class="bi bi-bar-chart"></i> {{ translate('stats') }}
+            </a>
             <div class="switch" data-language="{{ session.get('language', 'fr') }}" onclick="toggleLanguage(this)">
                 <div class="switch-labels">
                     <span class="fr">FR</span>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="{{ session.get('language', 'fr') }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ translate('stats_title') }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <img src="https://i.pinimg.com/originals/ed/35/f8/ed35f861be81be2548e514085fb19385.gif" alt="Nyan Cat" class="nyan-cat">
+            </a>
+            <a href="/snapshots" class="btn btn-primary ms-3">
+                <i class="bi bi-archive"></i> Snapshots
+            </a>
+            <a href="/stats" class="btn btn-success ms-3">
+                <i class="bi bi-bar-chart"></i> {{ translate('stats') }}
+            </a>
+            <div class="switch" data-language="{{ session.get('language', 'fr') }}" onclick="toggleLanguage(this)">
+                <div class="switch-labels">
+                    <span class="fr">FR</span>
+                    <span class="en">EN</span>
+                </div>
+                <div class="switch-handle"></div>
+            </div>
+        </div>
+    </nav>
+    <div class="container py-4">
+        <h1>{{ translate('stats_title') }}</h1>
+        {% if not stats %}
+            <p>{{ translate('no_snapshot_available') }}</p>
+        {% else %}
+            <div class="row text-center mb-4">
+                <div class="col-md-4 mb-3">
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">{{ translate('activities') }}</h5>
+                            <p class="display-6 mb-0">{{ stats.total_activities }}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">{{ translate('accommodations') }}</h5>
+                            <p class="display-6 mb-0">{{ stats.total_housings }}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <h5 class="card-title">{{ translate('restaurants') }}</h5>
+                            <p class="display-6 mb-0">{{ stats.total_restaurants }}</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <table class="table table-bordered">
+                <thead>
+                    <tr>
+                        <th>Pays</th>
+                        <th>{{ translate('activities') }}</th>
+                        <th>{{ translate('accommodations') }}</th>
+                        <th>{{ translate('restaurants') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% set countries = (stats.activities.keys() | list + stats.housings.keys() | list + stats.restaurants.keys() | list) | unique %}
+                    {% for country in countries %}
+                    <tr>
+                        <td>{{ country }}</td>
+                        <td>{{ stats.activities.get(country, 0) }}</td>
+                        <td>{{ stats.housings.get(country, 0) }}</td>
+                        <td>{{ stats.restaurants.get(country, 0) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            <h2 class="mt-4">{{ translate('housing_types_most_missing') }}</h2>
+            <ul>
+                {% for typ, count in stats.missing_by_type.items() %}
+                <li>{{ typ }}: {{ count }}</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+    function toggleLanguage(switchElement) {
+        const currentLang = switchElement.getAttribute('data-language');
+        const newLang = currentLang === 'fr' ? 'en' : 'fr';
+        window.location.href = `/set_language/${newLang}?next=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+    }
+    </script>
+</body>
+</html>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -34,7 +34,7 @@
         {% if not stats %}
             <p>{{ translate('no_snapshot_available') }}</p>
         {% else %}
-            <div class="row text-center mb-4">
+            <header class="row text-center mb-4">
                 <div class="col-md-4 mb-3">
                     <div class="card shadow-sm">
                         <div class="card-body">
@@ -59,11 +59,11 @@
                         </div>
                     </div>
                 </div>
-            </div>
+            </header>
             <table class="table table-bordered">
                 <thead>
                     <tr>
-                        <th>Pays</th>
+                        <th>{{ translate('country') }}</th>
                         <th>{{ translate('activities') }}</th>
                         <th>{{ translate('accommodations') }}</th>
                         <th>{{ translate('restaurants') }}</th>

--- a/tests/test_compute_stats.py
+++ b/tests/test_compute_stats.py
@@ -1,0 +1,47 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from utils.stats import compute_stats
+
+def test_compute_stats_basic():
+    data = {
+        'activities': {
+            'FR': {
+                'Park': {
+                    'activities': [
+                        {'has_photos': False, 'image_src': ''},
+                        {'has_photos': True, 'image_src': 'ok.jpg'}
+                    ]
+                }
+            }
+        },
+        'housings': {
+            'FR': {
+                'Park': {
+                    'housings': [
+                        {'has_photos': False, 'image_src': 'default/500x375.jpg', 'type': 'VIP'},
+                        {'has_photos': True, 'image_src': 'ok.jpg', 'type': 'VIP'}
+                    ]
+                }
+            }
+        },
+        'restaurants': {
+            'FR': {
+                'Park': {
+                    'restaurants': [
+                        {'has_photos': False, 'images': []},
+                        {'has_photos': True, 'images': ['ok.jpg']}
+                    ]
+                }
+            }
+        }
+    }
+    stats = compute_stats(data)
+    assert stats['activities']['FR'] == 1
+    assert stats['housings']['FR'] == 1
+    assert stats['restaurants']['FR'] == 1
+    assert stats['missing_by_type']['VIP'] == 1
+    assert stats['total_activities'] == 1
+    assert stats['total_housings'] == 1
+    assert stats['total_restaurants'] == 1
+

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -80,10 +80,11 @@
       "new_search": "New search",
       "snapshot_banner": "Latest data from snapshot",
       "show_latest_data": "Display most recent data",
-          "stats": "Statistics",
-          "stats_title": "Missing photos statistics",
-          "housing_types_most_missing": "Housing types with most missing photos",
-          "no_snapshot_available": "No snapshot available"
+      "stats": "Statistics",
+      "stats_title": "Missing photos statistics",
+      "housing_types_most_missing": "Housing types with most missing photos",
+      "no_snapshot_available": "No snapshot available",
+      "country": "Country"
     },
     "fr": {
       "welcome_message": "Bienvenue sur l'Iconofinder de Center Parcs",
@@ -166,9 +167,10 @@
       "new_search": "Nouvelle recherche",
       "snapshot_banner": "Affichage à partir du dernier snapshot JSON (données en cache)",
       "show_latest_data": "Afficher les données les plus récentes",
-          "stats": "Statistiques",
-          "stats_title": "Statistiques des photos manquantes",
-          "housing_types_most_missing": "Typologies d'hébergements les plus concernées",
-          "no_snapshot_available": "Aucun snapshot disponible"
+      "stats": "Statistiques",
+      "stats_title": "Statistiques des photos manquantes",
+      "housing_types_most_missing": "Typologies d'hébergements les plus concernées",
+      "no_snapshot_available": "Aucun snapshot disponible",
+      "country": "Pays"
     }
 }

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -79,7 +79,11 @@
       "image_placeholder": "Default image",
       "new_search": "New search",
       "snapshot_banner": "Latest data from snapshot",
-      "show_latest_data": "Display most recent data"
+      "show_latest_data": "Display most recent data",
+          "stats": "Statistics",
+          "stats_title": "Missing photos statistics",
+          "housing_types_most_missing": "Housing types with most missing photos",
+          "no_snapshot_available": "No snapshot available"
     },
     "fr": {
       "welcome_message": "Bienvenue sur l'Iconofinder de Center Parcs",
@@ -161,6 +165,10 @@
       "show_details": "Afficher les détails",
       "new_search": "Nouvelle recherche",
       "snapshot_banner": "Affichage à partir du dernier snapshot JSON (données en cache)",
-      "show_latest_data": "Afficher les données les plus récentes"
+      "show_latest_data": "Afficher les données les plus récentes",
+          "stats": "Statistiques",
+          "stats_title": "Statistiques des photos manquantes",
+          "housing_types_most_missing": "Typologies d'hébergements les plus concernées",
+          "no_snapshot_available": "Aucun snapshot disponible"
     }
 }

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -1,0 +1,40 @@
+def compute_stats(snapshot_data):
+    """Return statistics about missing photos per country and housing type."""
+    stats = {
+        'activities': {},
+        'housings': {},
+        'restaurants': {},
+        'missing_by_type': {},
+        'total_activities': 0,
+        'total_housings': 0,
+        'total_restaurants': 0,
+    }
+    default_fragment = 'default/500x375.jpg'
+
+    for country, parks in snapshot_data.get('activities', {}).items():
+        for park_data in parks.values():
+            for item in park_data.get('activities', []):
+                missing = not item.get('has_photos') or default_fragment in item.get('image_src', '')
+                if missing:
+                    stats['activities'][country] = stats['activities'].get(country, 0) + 1
+                    stats['total_activities'] += 1
+
+    for country, parks in snapshot_data.get('housings', {}).items():
+        for park_data in parks.values():
+            for item in park_data.get('housings', []):
+                missing = not item.get('has_photos') or default_fragment in item.get('image_src', '')
+                if missing:
+                    stats['housings'][country] = stats['housings'].get(country, 0) + 1
+                    stats['total_housings'] += 1
+                    typ = item.get('type', '?')
+                    stats['missing_by_type'][typ] = stats['missing_by_type'].get(typ, 0) + 1
+
+    for country, parks in snapshot_data.get('restaurants', {}).items():
+        for park_data in parks.values():
+            for item in park_data.get('restaurants', []):
+                missing = not item.get('has_photos') or len(item.get('images', [])) == 0
+                if missing:
+                    stats['restaurants'][country] = stats['restaurants'].get(country, 0) + 1
+                    stats['total_restaurants'] += 1
+
+    return stats

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -32,7 +32,11 @@ def compute_stats(snapshot_data):
     for country, parks in snapshot_data.get('restaurants', {}).items():
         for park_data in parks.values():
             for item in park_data.get('restaurants', []):
-                missing = not item.get('has_photos') or len(item.get('images', [])) == 0
+                missing = (
+                    not item.get('has_photos')
+                    or default_fragment in item.get('image_src', '')
+                    or len(item.get('images', [])) == 0
+                )
                 if missing:
                     stats['restaurants'][country] = stats['restaurants'].get(country, 0) + 1
                     stats['total_restaurants'] += 1


### PR DESCRIPTION
## Summary
- compute total missing counts in `compute_stats`
- display summary cards on `/stats` using Bootstrap 5
- expand unit test for totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400e29921483299bacbae3a0649e16