### PR TITLE
Add top missing metrics

### DIFF
--- a/templates/stats.html
+++ b/templates/stats.html
@@ -81,6 +81,34 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <h2 class="mt-4">{{ translate('top_missing_activities') }}</h2>
+            <ul>
+                {% for name, count in stats.top_activities %}
+                <li>{{ name }}: {{ count }}</li>
+                {% endfor %}
+            </ul>
+
+            <h2 class="mt-4">{{ translate('top_missing_housings') }}</h2>
+            <ul>
+                {% for name, count in stats.top_housings %}
+                <li>{{ name }}: {{ count }}</li>
+                {% endfor %}
+            </ul>
+
+            <h2 class="mt-4">{{ translate('top_missing_restaurants') }}</h2>
+            <ul>
+                {% for name, count in stats.top_restaurants %}
+                <li>{{ name }}: {{ count }}</li>
+                {% endfor %}
+            </ul>
+
+            <h2 class="mt-4">{{ translate('top_missing_items') }}</h2>
+            <ul>
+                {% for name, count in stats.top_missing_items %}
+                <li>{{ name }}: {{ count }}</li>
+                {% endfor %}
+            </ul>
+
             <h2 class="mt-4">{{ translate('housing_types_most_missing') }}</h2>
             <ul>
                 {% for typ, count in stats.missing_by_type.items() %}

--- a/tests/test_compute_stats.py
+++ b/tests/test_compute_stats.py
@@ -9,8 +9,8 @@ def test_compute_stats_basic():
             'FR': {
                 'Park': {
                     'activities': [
-                        {'has_photos': False, 'image_src': ''},
-                        {'has_photos': True, 'image_src': 'ok.jpg'}
+                        {'name': 'Act1', 'has_photos': False, 'image_src': ''},
+                        {'name': 'Act1', 'has_photos': True, 'image_src': 'ok.jpg'}
                     ]
                 }
             }
@@ -19,8 +19,8 @@ def test_compute_stats_basic():
             'FR': {
                 'Park': {
                     'housings': [
-                        {'has_photos': False, 'image_src': 'default/500x375.jpg', 'type': 'VIP'},
-                        {'has_photos': True, 'image_src': 'ok.jpg', 'type': 'VIP'}
+                        {'name': 'Hou1', 'has_photos': False, 'image_src': 'default/500x375.jpg', 'type': 'VIP'},
+                        {'name': 'Hou1', 'has_photos': True, 'image_src': 'ok.jpg', 'type': 'VIP'}
                     ]
                 }
             }
@@ -29,8 +29,8 @@ def test_compute_stats_basic():
             'FR': {
                 'Park': {
                     'restaurants': [
-                        {'has_photos': False, 'images': []},
-                        {'has_photos': True, 'images': ['ok.jpg']}
+                        {'name': 'Res1', 'has_photos': False, 'images': []},
+                        {'name': 'Res1', 'has_photos': True, 'images': ['ok.jpg']}
                     ]
                 }
             }
@@ -44,4 +44,46 @@ def test_compute_stats_basic():
     assert stats['total_activities'] == 1
     assert stats['total_housings'] == 1
     assert stats['total_restaurants'] == 1
+    assert dict(stats['top_activities'])['Act1'] == 1
+    assert dict(stats['top_housings'])['Hou1'] == 1
+    assert dict(stats['top_restaurants'])['Res1'] == 1
+
+def test_compute_stats_top_counts():
+    data = {
+        'activities': {
+            'FR': {
+                'Park': {
+                    'activities': [
+                        {'name': 'A1', 'has_photos': False, 'image_src': ''},
+                        {'name': 'A1', 'has_photos': False, 'image_src': ''},
+                        {'name': 'A2', 'has_photos': False, 'image_src': ''}
+                    ]
+                }
+            }
+        },
+        'housings': {
+            'FR': {
+                'Park': {
+                    'housings': [
+                        {'name': 'H1', 'has_photos': False, 'image_src': 'default/500x375.jpg', 'type': 'VIP'},
+                        {'name': 'H1', 'has_photos': False, 'image_src': 'default/500x375.jpg', 'type': 'VIP'}
+                    ]
+                }
+            }
+        },
+        'restaurants': {
+            'FR': {
+                'Park': {
+                    'restaurants': [
+                        {'name': 'R1', 'has_photos': False, 'images': []},
+                        {'name': 'R1', 'has_photos': False, 'images': []}
+                    ]
+                }
+            }
+        }
+    }
+    stats = compute_stats(data)
+    assert dict(stats['top_activities'])['A1'] == 2
+    assert dict(stats['top_housings'])['H1'] == 2
+    assert dict(stats['top_restaurants'])['R1'] == 2
 

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -83,6 +83,10 @@
       "stats": "Statistics",
       "stats_title": "Missing photos statistics",
       "housing_types_most_missing": "Housing types with most missing photos",
+      "top_missing_activities": "Top missing activities",
+      "top_missing_housings": "Top missing accommodations",
+      "top_missing_restaurants": "Top missing restaurants",
+      "top_missing_items": "Top missing items",
       "no_snapshot_available": "No snapshot available",
       "country": "Country"
     },
@@ -170,6 +174,10 @@
       "stats": "Statistiques",
       "stats_title": "Statistiques des photos manquantes",
       "housing_types_most_missing": "Typologies d'hébergements les plus concernées",
+      "top_missing_activities": "Activités les plus manquantes",
+      "top_missing_housings": "Hébergements les plus manquants",
+      "top_missing_restaurants": "Restaurants les plus manquants",
+      "top_missing_items": "Eléments avec le plus de photos manquantes",
       "no_snapshot_available": "Aucun snapshot disponible",
       "country": "Pays"
     }

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -1,3 +1,6 @@
+from collections import Counter
+
+
 def compute_stats(snapshot_data):
     """Return statistics about missing photos per country and housing type."""
     stats = {
@@ -8,8 +11,15 @@ def compute_stats(snapshot_data):
         'total_activities': 0,
         'total_housings': 0,
         'total_restaurants': 0,
+        'top_activities': [],
+        'top_housings': [],
+        'top_restaurants': [],
+        'top_missing_items': [],
     }
     default_fragment = 'default/500x375.jpg'
+    activity_counter = Counter()
+    housing_counter = Counter()
+    restaurant_counter = Counter()
 
     for country, parks in snapshot_data.get('activities', {}).items():
         for park_data in parks.values():
@@ -18,6 +28,8 @@ def compute_stats(snapshot_data):
                 if missing:
                     stats['activities'][country] = stats['activities'].get(country, 0) + 1
                     stats['total_activities'] += 1
+                    if item.get('name'):
+                        activity_counter[item['name']] += 1
 
     for country, parks in snapshot_data.get('housings', {}).items():
         for park_data in parks.values():
@@ -28,6 +40,8 @@ def compute_stats(snapshot_data):
                     stats['total_housings'] += 1
                     typ = item.get('type', '?')
                     stats['missing_by_type'][typ] = stats['missing_by_type'].get(typ, 0) + 1
+                    if item.get('name'):
+                        housing_counter[item['name']] += 1
 
     for country, parks in snapshot_data.get('restaurants', {}).items():
         for park_data in parks.values():
@@ -40,5 +54,13 @@ def compute_stats(snapshot_data):
                 if missing:
                     stats['restaurants'][country] = stats['restaurants'].get(country, 0) + 1
                     stats['total_restaurants'] += 1
+                    if item.get('name'):
+                        restaurant_counter[item['name']] += 1
+
+    stats['top_activities'] = activity_counter.most_common(5)
+    stats['top_housings'] = housing_counter.most_common(5)
+    stats['top_restaurants'] = restaurant_counter.most_common(5)
+    overall_counter = activity_counter + housing_counter + restaurant_counter
+    stats['top_missing_items'] = overall_counter.most_common(5)
 
     return stats


### PR DESCRIPTION
## Summary
- enhance `compute_stats` with counters for top missing items
- add tests for new top stats
- translate new stat titles in FR/EN
- expand statistics page with top metrics for activities, restaurants, housings and overall items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684020469dac83299a9420a054ea02ae