### PR TITLE
Implement statistics refresh feature

### DIFF
--- a/templates/stats.html
+++ b/templates/stats.html
@@ -31,6 +31,14 @@
     </nav>
     <div class="container py-4">
         <h1>{{ translate('stats_title') }}</h1>
+        {% if refreshed_at %}
+        <div class="alert alert-info" role="alert">
+            {{ translate('stats_refreshed') }} {{ refreshed_at }}
+        </div>
+        {% endif %}
+        <a href="{{ url_for('refresh_stats') }}" class="btn btn-secondary mb-3">
+            <i class="bi bi-arrow-clockwise"></i> {{ translate('refresh_stats') }}
+        </a>
         {% if not stats %}
             <p>{{ translate('no_snapshot_available') }}</p>
         {% else %}

--- a/translations/translations.json
+++ b/translations/translations.json
@@ -84,7 +84,9 @@
       "stats_title": "Missing photos statistics",
       "housing_types_most_missing": "Housing types with most missing photos",
       "no_snapshot_available": "No snapshot available",
-      "country": "Country"
+      "country": "Country",
+      "refresh_stats": "Refresh statistics",
+      "stats_refreshed": "Information updated since last snapshot on"
     },
     "fr": {
       "welcome_message": "Bienvenue sur l'Iconofinder de Center Parcs",
@@ -171,6 +173,8 @@
       "stats_title": "Statistiques des photos manquantes",
       "housing_types_most_missing": "Typologies d'hébergements les plus concernées",
       "no_snapshot_available": "Aucun snapshot disponible",
-      "country": "Pays"
+      "country": "Pays",
+      "refresh_stats": "Rafraîchir les statistiques",
+      "stats_refreshed": "Les informations ont été actualisées depuis le dernier snapshot le"
     }
 }


### PR DESCRIPTION
## Summary
- allow creating a new snapshot directly from the statistics page
- show banner when data were refreshed
- add translation keys for the refresh button and banner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840208831508329b58d643e98cf387e